### PR TITLE
fix: Declare cybernetic.exchange in topology setup

### DIFF
--- a/lib/cybernetic/core/transport/amqp/topology.ex
+++ b/lib/cybernetic/core/transport/amqp/topology.ex
@@ -232,6 +232,21 @@ defmodule Cybernetic.Core.Transport.AMQP.Topology do
         error
     end
 
+    # Declare cybernetic.exchange (legacy default used by tests and connection.ex)
+    case Exchange.declare(channel, "cybernetic.exchange", :topic, durable: true, auto_delete: false) do
+      :ok ->
+        Logger.debug("Declared legacy exchange: cybernetic.exchange (topic)")
+        :ok
+
+      {:error, {:resource_locked, _}} ->
+        Logger.debug("Legacy exchange already exists: cybernetic.exchange")
+        :ok
+
+      {:error, reason} = error ->
+        Logger.error("Failed to declare legacy exchange cybernetic.exchange: #{inspect(reason)}")
+        error
+    end
+
     :ok
   end
 


### PR DESCRIPTION
## Summary
- Added explicit declaration of cybernetic.exchange in AMQP topology setup
- This exchange is referenced throughout the codebase in tests and connection.ex but was never declared
- Follows same pattern as vsm.dlx dead letter exchange declaration

## Changes
- Updated lib/cybernetic/core/transport/amqp/topology.ex to declare cybernetic.exchange as a durable topic exchange

## Fixes
- Resolves `NOT_FOUND - no exchange 'cybernetic.exchange' in vhost '/'` errors
- Allows tests that publish to cybernetic.exchange to succeed

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>