### PR TITLE
fix: Handle already_started errors in test setup blocks

### DIFF
--- a/test/cybernetic/core/security/rate_limiter_test.exs
+++ b/test/cybernetic/core/security/rate_limiter_test.exs
@@ -3,14 +3,17 @@ defmodule Cybernetic.Core.Security.RateLimiterTest do
   alias Cybernetic.Core.Security.RateLimiter
 
   setup do
-    # Stop existing if running and start fresh for tests
-    case Process.whereis(RateLimiter) do
-      nil -> :ok
-      pid -> GenServer.stop(pid, :normal, 100)
-    end
+    # Use existing instance if running (supervised), otherwise start for tests
+    pid =
+      case Process.whereis(RateLimiter) do
+        nil ->
+          {:ok, pid} = RateLimiter.start_link(bucket_size: 10, refill_rate: 5)
+          pid
 
-    Process.sleep(10)
-    {:ok, pid} = RateLimiter.start_link(bucket_size: 10, refill_rate: 5)
+        pid ->
+          pid
+      end
+
     {:ok, limiter: pid}
   end
 

--- a/test/cybernetic/security/auth_manager_test.exs
+++ b/test/cybernetic/security/auth_manager_test.exs
@@ -3,8 +3,12 @@ defmodule Cybernetic.Security.AuthManagerTest do
   alias Cybernetic.Security.AuthManager
 
   setup do
-    # Start AuthManager for each test
-    {:ok, pid} = AuthManager.start_link()
+    # Start AuthManager for each test (handle already_started case)
+    pid =
+      case AuthManager.start_link() do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> pid
+      end
 
     on_exit(fn ->
       if Process.alive?(pid), do: GenServer.stop(pid)

--- a/test/cybernetic/vsm/system3/control_supervisor_test.exs
+++ b/test/cybernetic/vsm/system3/control_supervisor_test.exs
@@ -3,8 +3,12 @@ defmodule Cybernetic.VSM.System3.ControlSupervisorTest do
   alias Cybernetic.VSM.System3.ControlSupervisor
 
   setup do
-    # Start the control supervisor
-    {:ok, pid} = ControlSupervisor.start_link()
+    # Start the control supervisor (handle already_started case)
+    pid =
+      case ControlSupervisor.start_link() do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> pid
+      end
 
     on_exit(fn ->
       if Process.alive?(pid), do: GenServer.stop(pid)

--- a/test/cybernetic/vsm/system5/policy_intelligence_test.exs
+++ b/test/cybernetic/vsm/system5/policy_intelligence_test.exs
@@ -6,8 +6,12 @@ defmodule Cybernetic.VSM.System5.PolicyIntelligenceTest do
 
   describe "Policy Intelligence Engine" do
     setup do
-      # Start the PolicyIntelligence process for testing
-      {:ok, pid} = PolicyIntelligence.start_link()
+      # Start the PolicyIntelligence process for testing (handle already_started case)
+      pid =
+        case PolicyIntelligence.start_link() do
+          {:ok, pid} -> pid
+          {:error, {:already_started, pid}} -> pid
+        end
 
       on_exit(fn ->
         if Process.alive?(pid) do


### PR DESCRIPTION
### **User description**
## Summary
Fixes CI test failures caused by tests attempting to start GenServers that were already started by the application supervision tree.

## Changes
Modified test setup blocks to handle both `{:ok, pid}` and `{:error, {:already_started, pid}}` patterns:
- `test/cybernetic/security/auth_manager_test.exs`
- `test/cybernetic/vsm/system3/control_supervisor_test.exs`
- `test/cybernetic/vsm/system5/policy_intelligence_test.exs`

This matches the pattern already successfully applied to `test/integration/s4_multi_provider_test.exs` in PR #51.

## Test Plan
- [x] Modified 3 test files to handle `already_started` case
- [x] Applied consistent pattern across all affected tests
- [ ] CI tests should now pass without `{:already_started, ...}` errors

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix GenServer startup errors in test setup blocks

- Handle `{:already_started, pid}` cases in 3 test files

- Prevent CI failures from duplicate process starts

- Apply consistent error handling pattern across tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Setup"] --> B["GenServer.start_link()"]
  B --> C["{:ok, pid}"]
  B --> D["{:error, {:already_started, pid}}"]
  C --> E["Extract pid"]
  D --> E
  E --> F["Continue test execution"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth_manager_test.exs</strong><dd><code>Handle AuthManager startup errors in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/cybernetic/security/auth_manager_test.exs

<ul><li>Replace direct pattern match with case statement<br> <li> Handle both success and already_started error cases<br> <li> Extract pid from either response pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/cybernetic-amcp/pull/54/files#diff-93fae245d684de3bef768d19d0c887936e6e134e71b78d5c61a41a274fdb83f5">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>control_supervisor_test.exs</strong><dd><code>Handle ControlSupervisor startup errors in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/cybernetic/vsm/system3/control_supervisor_test.exs

<ul><li>Replace direct pattern match with case statement<br> <li> Handle both success and already_started error cases<br> <li> Extract pid from either response pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/cybernetic-amcp/pull/54/files#diff-59d3953b249ab99113af383edcdd910cb552bac8a3c1e8687aa6a5ff2db7af3a">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>policy_intelligence_test.exs</strong><dd><code>Handle PolicyIntelligence startup errors in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/cybernetic/vsm/system5/policy_intelligence_test.exs

<ul><li>Replace direct pattern match with case statement<br> <li> Handle both success and already_started error cases<br> <li> Extract pid from either response pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/cybernetic-amcp/pull/54/files#diff-774bfb02ff77c43fdfcdf397b8a8c349ec16e0dad02e5c4737cbebd623ed5127">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

