### PR TITLE
fix: Add System5.Policy to supervision tree and fix Service.analyze calls

### DIFF
--- a/lib/cybernetic/application.ex
+++ b/lib/cybernetic/application.ex
@@ -53,6 +53,8 @@ defmodule Cybernetic.Application do
           {Cybernetic.Core.Aggregator.CentralAggregator, []},
           # S5 SOP Engine (must be before S4 Bridge so it can receive messages)
           {Cybernetic.VSM.System5.SOPEngine, []},
+          # S5 Policy Store
+          {Cybernetic.VSM.System5.Policy, []},
           # S5 Policy Intelligence Engine
           {Cybernetic.VSM.System5.PolicyIntelligence, []},
           # S4 Intelligence Layer

--- a/test/integration/s4_multi_provider_test.exs
+++ b/test/integration/s4_multi_provider_test.exs
@@ -181,7 +181,7 @@ defmodule Cybernetic.Integration.S4MultiProviderTest do
       Logger.info("🚀 Starting end-to-end S4 analysis...")
 
       # Analyze episode through S4 Service
-      case Service.analyze(episode) do
+      case Service.analyze_episode(episode) do
         {:ok, analysis} ->
           Logger.info("✓ S4 analysis completed successfully")
 
@@ -315,7 +315,7 @@ defmodule Cybernetic.Integration.S4MultiProviderTest do
         })
 
       # Trigger analysis that should emit telemetry
-      Service.analyze(episode)
+      Service.analyze_episode(episode)
 
       # Collect telemetry events
       received_events = collect_telemetry_events([], 5000)


### PR DESCRIPTION
## Changes
- Added System5.Policy to application supervision tree
- Fixed incorrect Service.analyze/1 calls to use Service.analyze_episode/2

## Fixes
- Resolves 'no process' errors for Cybernetic.VSM.System5.Policy in integration tests  
- Resolves UndefinedFunctionError for Service.analyze/1

## Testing
Integration tests should now have System5.Policy available and Service calls should work correctly.