### PR TITLE
fix: Add Dockerfile path to Docker build action

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -187,6 +187,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
### **User description**
## Summary
- Add `file: docker/Dockerfile` parameter to Docker build action in CI/CD Pipeline workflow

## Problem
The Docker build was failing with "open Dockerfile: no such file or directory" because the Dockerfile is located in `docker/Dockerfile` but the build action was looking for it in the root directory.

## Solution
Added the `file` parameter to explicitly specify the path to the Dockerfile.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Docker build failure by specifying Dockerfile path

- Add `file: docker/Dockerfile` parameter to build action


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI/CD Workflow"] --> B["Docker Build Action"]
  B --> C["Dockerfile Path Fixed"]
  C --> D["Successful Build"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-cd.yml</strong><dd><code>Fix Dockerfile path in Docker build action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-cd.yml

<ul><li>Add <code>file: docker/Dockerfile</code> parameter to Docker build action<br> <li> Fix build failure caused by incorrect Dockerfile path lookup</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/cybernetic-amcp/pull/58/files#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

