### PR TITLE
fix: Remove non-existent docker/config copy from Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,9 +61,6 @@ WORKDIR /app
 # Copy release from builder
 COPY --from=builder --chown=cybernetic:cybernetic /app/_build/prod/rel/cybernetic ./
 
-# Copy configuration templates
-COPY --chown=cybernetic:cybernetic docker/config ./config
-
 # Set environment
 ENV HOME=/app \
     LANG=en_US.UTF-8 \


### PR DESCRIPTION
## Problem
The Docker build is failing with:
```
ERROR: failed to build: failed to solve: failed to compute cache key: 
"/docker/config": not found
```

## Root Cause
Line 65 of the Dockerfile attempts to copy `docker/config` directory which doesn't exist.

The config directory is already properly handled:
- Copied to builder stage on line 27 (`COPY config config`)
- Included in the release build

## Solution
Remove the incorrect COPY instruction for `docker/config` on line 65.

The release already contains the necessary configuration from the builder stage.

## Testing
- Docker build should now succeed without errors
- Configuration is still available through the release