### PR TITLE
Hotfix: Use setup fixture in 'enables sync manually' test

### DIFF
--- a/test/cybernetic/core/crdt/context_graph_test.exs
+++ b/test/cybernetic/core/crdt/context_graph_test.exs
@@ -25,7 +25,7 @@ defmodule Cybernetic.Core.CRDT.ContextGraphTest do
       assert Process.alive?(pid)
     end
 
-    test "enables sync manually" do
+    test "enables sync manually", %{graph: pid} do
       # This should trigger :wire_neighbors message
       ContextGraph.enable_sync()
 
@@ -33,7 +33,6 @@ defmodule Cybernetic.Core.CRDT.ContextGraphTest do
       Process.sleep(50)
 
       # Should not crash
-      pid = Process.whereis(ContextGraph)
       assert Process.alive?(pid)
     end
 


### PR DESCRIPTION
### **User description**
Fixes the test failure from run 18065059395 that was merged to main.

The test was calling `Process.whereis(ContextGraph)` which returns `nil` in CI, causing `ArgumentError: not a pid`.

Changed the test to use `%{graph: pid}` from the setup fixture instead.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix test failure by using setup fixture instead of `Process.whereis`

- Prevent `ArgumentError: not a pid` when `ContextGraph` returns `nil` in CI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test calls Process.whereis(ContextGraph)"] --> B["Returns nil in CI environment"]
  B --> C["Causes ArgumentError: not a pid"]
  C --> D["Fixed by using %{graph: pid} from setup fixture"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>context_graph_test.exs</strong><dd><code>Use setup fixture instead of process lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/cybernetic/core/crdt/context_graph_test.exs

<ul><li>Modified test function to accept <code>%{graph: pid}</code> parameter from setup <br>fixture<br> <li> Removed <code>Process.whereis(ContextGraph)</code> call that was returning <code>nil</code> in <br>CI<br> <li> Used the <code>pid</code> variable from fixture instead of looking up process</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/cybernetic-amcp/pull/61/files#diff-3606ef4ac553004fa7063d23b3c510fa38d1b5838ece11a6a776d4c00c4d1b3f">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

