### PR TITLE
fix: Use setup fixture in 'enables sync manually' test

### DIFF
--- a/test/cybernetic/core/crdt/context_graph_test.exs
+++ b/test/cybernetic/core/crdt/context_graph_test.exs
@@ -25,7 +25,7 @@ defmodule Cybernetic.Core.CRDT.ContextGraphTest do
       assert Process.alive?(pid)
     end
 
-    test "enables sync manually" do
+    test "enables sync manually", %{graph: pid} do
       # This should trigger :wire_neighbors message
       ContextGraph.enable_sync()
 
@@ -33,7 +33,6 @@ defmodule Cybernetic.Core.CRDT.ContextGraphTest do
       Process.sleep(50)
 
       # Should not crash
-      pid = Process.whereis(ContextGraph)
       assert Process.alive?(pid)
     end
 


### PR DESCRIPTION
### **User description**
Fixes the failing test by using the setup fixture's pid instead of calling Process.whereis directly.

This ensures the test uses the correct pid from the setup block, which handles both supervised and manually-started processes.

Fixes run #425 failure on main branch.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix failing test by using setup fixture's pid

- Replace `Process.whereis` call with fixture parameter

- Ensure correct process reference in test scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Setup Fixture"] --> B["Provides PID"]
  B --> C["Test Uses Fixture PID"]
  D["Process.whereis Call"] --> E["Removed"]
  C --> F["Test Passes Reliably"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>context_graph_test.exs</strong><dd><code>Use setup fixture pid in test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/cybernetic/core/crdt/context_graph_test.exs

<ul><li>Modified test function to accept <code>%{graph: pid}</code> parameter<br> <li> Removed <code>Process.whereis(ContextGraph)</code> call<br> <li> Used fixture-provided pid directly in assertion</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/cybernetic-amcp/pull/62/files#diff-3606ef4ac553004fa7063d23b3c510fa38d1b5838ece11a6a776d4c00c4d1b3f">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

